### PR TITLE
Alter import statements to allow relative import

### DIFF
--- a/py/TemplateTrainingCase.py
+++ b/py/TemplateTrainingCase.py
@@ -1,5 +1,5 @@
-from py.network import Network
-from py.node import Node
+from network import Network
+from node import Node
 
 
 # determines the fitness of a network

--- a/py/abstractionLayer.py
+++ b/py/abstractionLayer.py
@@ -3,7 +3,7 @@ from random import uniform
 from axiom import Axiom
 from node import Node
 
-from py.mathFuncs import sigmoid
+from mathFuncs import sigmoid
 
 
 class AbstractionLayer:

--- a/py/network.py
+++ b/py/network.py
@@ -1,4 +1,4 @@
-from py.abstractionLayer import AbstractionLayer
+from abstractionLayer import AbstractionLayer
 from random import randint
 
 class Network:


### PR DESCRIPTION
Previously I was unable to run the test case due to Python complaining about being unable to find module `py`.

```
➜  PyNeuralNet git:(master) ✗ python3 py/TemplateTrainingCase.py 
Traceback (most recent call last):
  File "py/TemplateTrainingCase.py", line 1, in <module>
    from py.network import Network
ImportError: No module named 'py'
```

By changing the import statements to relative ones, I am now able to run the code. Not sure if this is best practice or not, or breaks your build, but this is what I needed to do to get things working. Running Python 3.5.2.