### PR TITLE
Refactor generation signature

### DIFF
--- a/py/TemplateTrainingCase.py
+++ b/py/TemplateTrainingCase.py
@@ -6,25 +6,21 @@ def fitness():
     pass
 
 # converts data from a source into nodes for first abstraction layer
-def inputData():
-    return [
-        NodeFactory.create(1),
-        NodeFactory.create(1),
-        NodeFactory.create(1)
-    ]
+inputs = [
+    NodeFactory.create(1),
+    NodeFactory.create(1),
+    NodeFactory.create(1)
+]
 
 # converts data from a abstraction layer into data
-def outputData():
-    return [
-        NodeFactory.create(1),
-        NodeFactory.create(1),
-        NodeFactory.create(1)
-    ]
+outputs = [
+    NodeFactory.create(1),
+    NodeFactory.create(1),
+    NodeFactory.create(1)
+]
 
-inputs = inputData()
-outputs = outputData()
+testNet = Network(inputs, outputs).generate(4, 20, False, True)
 
-testNet = Network().generate(inputs,outputs,4,20,False,True)
 testNet.draw(512,512)
 
 testNet.print(True)

--- a/py/network.py
+++ b/py/network.py
@@ -9,10 +9,10 @@ from random import uniform
 
 class Network:
 
-    def __init__(self):
+    def __init__(self, inputs, outputs):
         self.abstractionLayers = []
-        self.inputNodes = []
-        self.outputNodes = []
+        self.inputNodes = inputs
+        self.outputNodes = outputs
         self.axiomOutList = []
 
     def print(self, verbose = False):
@@ -109,10 +109,7 @@ class Network:
 
     # generates a new random network, max layers, max nodes per layer and max
     # axiom weighting can all be determined
-    def generate(self,inputNodes,outputNodes,numAbstractions,numNodesPerLayer,abstractionsMax = False, nodesPerLayerMax = False):
-        self.inputNodes = inputNodes
-        self.outputNodes = outputNodes
-
+    def generate(self, numAbstractions, numNodesPerLayer, abstractionsMax = False, nodesPerLayerMax = False):
         if abstractionsMax:
             numAbstractions = randint(1, numAbstractions)
 


### PR DESCRIPTION
This PR refactors the generation signature to not require inputs / outputs to be passed in, and relies instead on taking them from the network's constructor