### PR TITLE
Completely decouple visualisation from Network

### DIFF
--- a/py/TemplateTrainingCase.py
+++ b/py/TemplateTrainingCase.py
@@ -1,5 +1,6 @@
 from network import Network
 from node.Factory import Factory as NodeFactory
+from visualization import Visualization
 
 # determines the fitness of a network
 def fitness():
@@ -19,8 +20,8 @@ outputs = [
     NodeFactory.create(1)
 ]
 
-testNet = Network(inputs, outputs).generate(4, 20, False, True)
+testNetwork = Network(inputs, outputs).generate(4, 20, False, True)
 
-testNet.draw(512,512)
+testNetwork.print(True)
 
-testNet.print(True)
+Visualization(inputs, outputs, testNetwork.abstractionLayers, testNetwork.axiomOutList).draw(512,512)

--- a/py/network.py
+++ b/py/network.py
@@ -3,7 +3,6 @@ from random import randint
 from axiom import Axiom
 from mathFuncs import sigmoid
 from random import uniform
-from visualization import Visualization
 
 class Network:
 
@@ -12,16 +11,12 @@ class Network:
         self.inputNodes = inputs
         self.outputNodes = outputs
         self.axiomOutList = []
-        self.vis = Visualization(inputs, outputs, self.abstractionLayers, self.axiomOutList)
 
     def print(self, verbose = False):
         print("Network: " + str(self))
         if verbose:
             for aL in self.abstractionLayers:
                 aL.print(True)
-
-    def draw(self,w=256,h=256):
-        self.vis.draw(w,h)
 
     # generates a new random network, max layers, max nodes per layer and max
     # axiom weighting can all be determined


### PR DESCRIPTION
This PR completely decouples the visualisation of the network from the network itself, the network does not need to know about how it is being rendered.