### PR TITLE
Refactor network generation

### DIFF
--- a/py/TemplateTrainingCase.py
+++ b/py/TemplateTrainingCase.py
@@ -19,7 +19,7 @@ outputs = [
     NodeFactory.create(1)
 ]
 
-testNet = Network(inputs, outputs).generate(4, 20, False, True)
+testNet = Network(inputs, outputs).generate(4, 20, True)
 
 testNet.draw(512,512)
 

--- a/py/abstractionLayer.py
+++ b/py/abstractionLayer.py
@@ -9,9 +9,9 @@ from mathFuncs import sigmoid
 class AbstractionLayer:
     """Abstraction layers hold collections of nodes"""
 
-    def __init__(self):
+    def __init__(self, prevLayerNodes = []):
         self.nodes = []
-        self.prevLayerNodes = []
+        self.prevLayerNodes = prevLayerNodes
         self.axiomList = []
 
     def print(self, verbose = False):
@@ -22,10 +22,6 @@ class AbstractionLayer:
             print(self.axiomList)
             for axiom in self.axiomList:
                 axiom.print()
-
-    def create(self, prevLNodes):
-        self.prevLayerNodes = prevLNodes
-        return self
 
     def addNewNode(self):
         axIn = []

--- a/py/network.py
+++ b/py/network.py
@@ -27,17 +27,15 @@ class Network:
     # axiom weighting can all be determined
     def generate(self, nLayers, numNodesPerLayer, nodesPerLayerMax = False):
         for i in range(nLayers):
-            aL = AbstractionLayer()
-            if i > 0:
-                self.abstractionLayers.append(aL.create(self.abstractionLayers[i-1].nodes))
-            else:
-                self.abstractionLayers.append(aL.create(self.inputNodes))
+            nodes = self.abstractionLayers[i-1].nodes if i > 0 else self.inputNodes
+            layer = AbstractionLayer(nodes)
+            self.abstractionLayers.append(layer)
 
             if nodesPerLayerMax:
                 numNodesPerLayer = randint(len(self.outputNodes), numNodesPerLayer) # ensures diminishing tree to the right
 
             for j in range(numNodesPerLayer):
-                aL.addNewNode()
+                layer.addNewNode()
 
         for outNode in self.outputNodes:
             axOut = []

--- a/py/network.py
+++ b/py/network.py
@@ -25,18 +25,16 @@ class Network:
 
     # generates a new random network, max layers, max nodes per layer and max
     # axiom weighting can all be determined
-    def generate(self, numAbstractions, numNodesPerLayer, abstractionsMax = False, nodesPerLayerMax = False):
-        if abstractionsMax:
-            numAbstractions = randint(1, numAbstractions)
-
-        for i in range(numAbstractions):
+    def generate(self, nLayers, numNodesPerLayer, nodesPerLayerMax = False):
+        for i in range(nLayers):
             aL = AbstractionLayer()
-            if nodesPerLayerMax:
-                numNodesPerLayer = randint(len(self.outputNodes), numNodesPerLayer) # ensures diminishing tree to the right
             if i > 0:
                 self.abstractionLayers.append(aL.create(self.abstractionLayers[i-1].nodes))
             else:
                 self.abstractionLayers.append(aL.create(self.inputNodes))
+
+            if nodesPerLayerMax:
+                numNodesPerLayer = randint(len(self.outputNodes), numNodesPerLayer) # ensures diminishing tree to the right
 
             for j in range(numNodesPerLayer):
                 aL.addNewNode()


### PR DESCRIPTION
This PR refactors `Network`'s `generate` method:

- Drop unused `abstractionsMax` parameter
- Simplify logic inside `generate` method body