### PR TITLE
Remove unused `go` methods

### DIFF
--- a/py/abstractionLayer.py
+++ b/py/abstractionLayer.py
@@ -41,8 +41,3 @@ class AbstractionLayer:
 
     def removeNode(self, n):
         self.nodes.remove(n)
-
-    def go(self):
-        for node in self.nodes:
-            node.go()
-

--- a/py/network.py
+++ b/py/network.py
@@ -50,10 +50,6 @@ class Network:
 
         return self
 
-    def go(self):
-        for aL in self.abstractionLayers:
-            aL.go()
-
     # on a new birth there is a small chance of mutation of axiom weights,
     # a smaller chance of creating a new node in an existing abstraction layer,
     # and an even smaller chance of creating an entirely new abstraction layer.


### PR DESCRIPTION
Looks like these methods are unused / redundant now, so this PR removes them from the repo